### PR TITLE
Handle new news feed suggested group structure

### DIFF
--- a/greasyfork-release/fb-clean-my-feeds.user.js
+++ b/greasyfork-release/fb-clean-my-feeds.user.js
@@ -3587,6 +3587,9 @@
         // -- nb: "x people recently commented" posts have similar structure - suggested/recommended posts don't start with a number ...
 
         const queries = [
+            // -- October 2023
+            'div[aria-posinset] > div > div > div > div > div > div:nth-of-type(2) > div > div > div:nth-of-type(2) > div > div:nth-of-type(2) > div > div:nth-of-type(2) > span > span > span:nth-of-type(2)',
+            'div[aria-describedby] > div > div > div > div > div > div:nth-of-type(2) > div > div > div:nth-of-type(2) > div > div:nth-of-type(2) > div > div:nth-of-type(2) > span > span > span:nth-of-type(2)',
             // -- May 2023
             'div[aria-posinset] > div > div > div > div > div > div:nth-of-type(2) > div > div > div:nth-of-type(1) > div > div > span',
             'div[aria-describedby] > div > div > div > div > div > div:nth-of-type(2) > div > div > div:nth-of-type(1) > div > div > span',


### PR DESCRIPTION
Looks like there's been another structural change.  I copied the style of the last update to the suggested posts (from May) and updated the queries.  I don't know if both of the aria-posinset and aria-describedby versions are required, either one worked in my testing.

```js
>> var x = document.querySelectorAll('div[aria-posinset] > div > div > div > div > div > div:nth-of-type(2) > div > div > div:nth-of-type(2) > div > div:nth-of-type(2) > div > div:nth-of-type(2) > span > span > span:nth-of-type(2)');
<- undefined
>> x[2].innerHTML;
<- "Suggested for you" 
```