### PR TITLE
Corrects a typo `VARS.Options.VERBOSITY_MESSSAGE_BG_COLOUR` property

### DIFF
--- a/greasyfork-release/fb-clean-my-feeds.user.js
+++ b/greasyfork-release/fb-clean-my-feeds.user.js
@@ -2462,7 +2462,7 @@ const masterKeyWords = {
             'position: relative; ' +
             'margin:1.5rem auto; padding:0.5rem 1rem; border-radius:0.55rem; width:85%; font-style:italic;' +
             ((VARS.Options.VERBOSITY_MESSAGE_COLOUR === '') ? '' : ` color: ${VARS.Options.VERBOSITY_MESSAGE_COLOUR}; `) +
-            `background-color:${(VARS.Options.VERBOSITY_MESSSAGE_BG_COLOUR === '') ? masterKeyWords.defaults.VERBOSITY_MESSAGE_BG_COLOUR : VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR};`
+            `background-color:${(VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR === '') ? masterKeyWords.defaults.VERBOSITY_MESSAGE_BG_COLOUR : VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR};`
         );
         addToSS(
             `details[${postAtt}] > summary:hover`,
@@ -2513,7 +2513,7 @@ const masterKeyWords = {
             `h6[${postAttTab}]`,
             'border-radius: 0.55rem 0.55rem 0 0; width:75%; margin:0 auto; padding: 0.45rem 0.25rem; font-style:italic; text-align:center; font-weight:normal;' +
             ((VARS.Options.VERBOSITY_MESSAGE_COLOUR === '') ? '' : `  color: ${VARS.Options.VERBOSITY_MESSAGE_COLOUR}; `) +
-            `background-color:${(VARS.Options.VERBOSITY_MESSSAGE_BG_COLOUR === '') ? masterKeyWords.defaults.VERBOSITY_MESSAGE_BG_COLOUR : VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR}; `
+            `background-color:${(VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR === '') ? masterKeyWords.defaults.VERBOSITY_MESSAGE_BG_COLOUR : VARS.Options.VERBOSITY_MESSAGE_BG_COLOUR}; `
         );
 
 


### PR DESCRIPTION
Corrects a typo in the `VARS.Options` property.  
The `VERBOSITY_MESSSAGE_BG_COLOUR` setting had a misspelling ("MESSSAGE" instead of "MESSAGE").