### PR TITLE
Update queryFollow to fix issue #80

### DIFF
--- a/greasyfork-release/fb-clean-my-feeds.user.js
+++ b/greasyfork-release/fb-clean-my-feeds.user.js
@@ -5098,7 +5098,7 @@ const masterKeyWords = {
         // const queryFollow = ':scope h4[id] > span > div > span';
         // - 09/2024 - added the extra query
         //const queryFollow = ':scope h4[id] > span > div > span, :scope h4[id] > span > span > div > span, :scope h4[id] > div > span > span[class] > div[class] > span[class]';
-        const queryFollow = [':scope h4[id] > span > div > span', ':scope h4[id] > span > span > div > span', ':scope h4[id] > div > span > span[class] > div[class] > span[class]'];
+        const queryFollow = [':scope h4[id] > span > div > span', ':scope h4[id] > span > span > div > span', ':scope h4[id] > div > span > span[class] > div[class] > span[class]', ':scope h4[id] > span > span > span > span'];
         const elementsFollow = querySelectorAllNoChildren(post, queryFollow, 0, false);
         // if (elementsFollow.length > 0) console.info(log + "nf_isFollow(post); elementsFollow:", elementsFollow, post);
         return (elementsFollow.length !== 1) ? '' : KeyWords.NF_FOLLOW;


### PR DESCRIPTION
**Issue:**
The `nf_isFollow` function's `queryFollow` selector was not correctly identifying follow buttons on Facebook. (HTML structure changed on Mar 22nd, 2025) issue

**Changes:**

*   `nf_isFollow`: Added the new CSS selector to the `queryFollow` function.