### PR TITLE
Defer the observation of documentElement

### DIFF
--- a/greasyfork-release/fb-clean-my-feeds.user.js
+++ b/greasyfork-release/fb-clean-my-feeds.user.js
@@ -7250,10 +7250,21 @@ const masterKeyWords = {
     });
 
     // -- Start observing the target node for configured mutations
-    observer.observe(document.documentElement, {
-        attributes: true, // Observe changes to attributes
-        attributeFilter: ['class'] // Only observe changes to the 'class' attribute
-    });
+    function startObserving() {
+        observer.observe(document.documentElement, {
+            attributes: true, // Observe changes to attributes
+            attributeFilter: ['class'] // Only observe changes to the 'class' attribute
+        });
+    }
+
+    if (document.documentElement) {
+        startObserving();
+    } else {
+        var obs = new MutationObserver(function () {
+            if (document.documentElement) { obs.disconnect(); startObserving(); }
+        });
+        obs.observe(document, {childList: true});
+    }
 
     // setTimeout(startUp, 50);
     startUp();


### PR DESCRIPTION
I find that the v5.02 script sometimes (1 out of 7~8 refreshes) crashes upon startup, resulting a weird message "TypeError: document.documentElement is null" in the console. It does not produce an observable error on the web app, but the CMF icon will not be injected to the site, so the userscript is not activated at all.

I am using Greasemonkey on Firefox 138. The breakage happens at the end of the script, near `observer.observe(document.documentElement...`. I suspect that the userscript executes in a sandboxed environment, when the real website is loading. There is a slim chance of a race condition.

See also https://github.com/greasemonkey/greasemonkey/issues/2996
