### PR TITLE
feat: update isFollow rules

### DIFF
--- a/greasyfork-release/fb-clean-my-feeds.user.js
+++ b/greasyfork-release/fb-clean-my-feeds.user.js
@@ -5098,7 +5098,13 @@ const masterKeyWords = {
         // const queryFollow = ':scope h4[id] > span > div > span';
         // - 09/2024 - added the extra query
         //const queryFollow = ':scope h4[id] > span > div > span, :scope h4[id] > span > span > div > span, :scope h4[id] > div > span > span[class] > div[class] > span[class]';
-        const queryFollow = [':scope h4[id] > span > div > span', ':scope h4[id] > span > span > div > span', ':scope h4[id] > div > span > span[class] > div[class] > span[class]'];
+        const queryFollow = [
+          ":scope h4[id] > span > div > span",
+          ":scope h4[id] > span > span > div > span",
+          ":scope h4[id] > div > span > span[class] > div[class] > span[class]",
+          ":scope h4[id] > span > span:nth-child(3) > span:nth-child(2) > div > span",
+          ":scope h4[id] > span > span:nth-child(2) > span:nth-child(2) > div > span",
+        ];
         const elementsFollow = querySelectorAllNoChildren(post, queryFollow, 0, false);
         // if (elementsFollow.length > 0) console.info(log + "nf_isFollow(post); elementsFollow:", elementsFollow, post);
         return (elementsFollow.length !== 1) ? '' : KeyWords.NF_FOLLOW;


### PR DESCRIPTION
There are some Follow posts are not being captured by the tool, even that I have enabled the "Follow" option. 
![image](https://github.com/user-attachments/assets/4f73d5be-e8c6-4571-9338-cedb7ce28725)


With this PR, I'm capturing all those follow posts. Please note that I only tested it with "Spanish." However, since it's just a querySelector, it shouldn't negatively affect any other languages.